### PR TITLE
Pass the input folder to the Generate render functions.

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/ApiDocs.fs
+++ b/src/FSharp.Formatting.ApiDocs/ApiDocs.fs
@@ -85,7 +85,8 @@ type ApiDocs =
             ?libDirs,
             ?otherFlags,
             ?urlRangeHighlight,
-            ?onError
+            ?onError,
+            ?menuTemplateFolder
         ) =
         let root = defaultArg root "/"
         let qualify = defaultArg qualify false
@@ -106,7 +107,7 @@ type ApiDocs =
                 extensions = extensions
             )
 
-        let renderer = GenerateHtml.HtmlRender(model)
+        let renderer = GenerateHtml.HtmlRender(model, ?menuTemplateFolder = menuTemplateFolder)
 
         let index = GenerateSearchIndex.searchIndexEntriesForModel model
 
@@ -184,7 +185,8 @@ type ApiDocs =
             ?libDirs,
             ?otherFlags,
             ?urlRangeHighlight,
-            ?onError
+            ?onError,
+            ?menuTemplateFolder
         ) =
         let root = defaultArg root "/"
         let qualify = defaultArg qualify false
@@ -205,7 +207,7 @@ type ApiDocs =
                 extensions = extensions
             )
 
-        let renderer = GenerateMarkdown.MarkdownRender(model)
+        let renderer = GenerateMarkdown.MarkdownRender(model, ?menuTemplateFolder = menuTemplateFolder)
 
         let index = GenerateSearchIndex.searchIndexEntriesForModel model
 

--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -13,7 +13,7 @@ open FSharp.Formatting.HtmlModel.Html
 /// Embed some HTML generateed in GenerateModel
 let embed (x: ApiDocHtml) = !!x.HtmlText
 
-type HtmlRender(model: ApiDocModel) =
+type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
     let root = model.Root
     let collectionName = model.Collection.CollectionName
     let qualify = model.Qualify
@@ -615,10 +615,17 @@ type HtmlRender(model: ApiDocModel) =
                   | _ -> () ]
 
     let listOfNamespacesNav otherDocs (nsOpt: ApiDocNamespace option) =
-        let _ = FSharp.Formatting.Menu.createMenu ()
-        listOfNamespacesNavAux otherDocs nsOpt
-        |> List.map (fun html -> html.ToString())
-        |> String.concat "             \n"
+        let isTemplatingAvailable =
+            match menuTemplateFolder with
+            | None -> false
+            | Some input -> FSharp.Formatting.Menu.isTemplatingAvailable input
+
+        if isTemplatingAvailable then
+            "TODO!"
+        else
+            listOfNamespacesNavAux otherDocs nsOpt
+            |> List.map (fun html -> html.ToString())
+            |> String.concat "             \n"
 
     /// Get the substitutions relevant to all
     member _.GlobalSubstitutions: Substitutions =

--- a/src/FSharp.Formatting.ApiDocs/GenerateMarkdown.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateMarkdown.fs
@@ -22,7 +22,7 @@ let embed (x: ApiDocHtml) = !!(htmlString x)
 let embedSafe (x: ApiDocHtml) = !!(htmlStringSafe x)
 let br = !! "<br />"
 
-type MarkdownRender(model: ApiDocModel) =
+type MarkdownRender(model: ApiDocModel, ?menuTemplateFolder: string) =
     let root = model.Root
     let collectionName = model.Collection.CollectionName
     let qualify = model.Qualify
@@ -362,9 +362,17 @@ type MarkdownRender(model: ApiDocModel) =
                       | _ -> () ]
 
     let listOfNamespaces otherDocs nav (nsOpt: ApiDocNamespace option) =
-        listOfNamespacesAux otherDocs nav nsOpt
-        |> List.map (fun html -> html.ToString())
-        |> String.concat "             \n"
+        let isTemplatingAvailable =
+            match menuTemplateFolder with
+            | None -> false
+            | Some input -> FSharp.Formatting.Menu.isTemplatingAvailable input
+
+        if isTemplatingAvailable then
+            "TODO!"
+        else
+            listOfNamespacesAux otherDocs nav nsOpt
+            |> List.map (fun html -> html.ToString())
+            |> String.concat "             \n"
 
     /// Get the substitutions relevant to all
     member _.GlobalSubstitutions: Substitutions =

--- a/src/fsdocs-tool/BuildCommand.fs
+++ b/src/fsdocs-tool/BuildCommand.fs
@@ -527,7 +527,8 @@ type internal DocContent
                    | _ -> () |]
 
     member _.GetNavigationEntries(docModels: (string * bool * LiterateDocModel) list) =
-        let _ = FSharp.Formatting.Menu.createMenu ()
+        let _ = FSharp.Formatting.Menu.createMenu "fake header" []
+
         let modelsForList =
             [ for thing in docModels do
                   match thing with
@@ -1490,7 +1491,8 @@ type CoreBuildOptions(watch) =
                                     otherFlags = apiDocOtherFlags @ Seq.toList this.fscoptions,
                                     root = root,
                                     libDirs = paths,
-                                    onError = onError
+                                    onError = onError,
+                                    menuTemplateFolder = this.input
                                 )
                             | OutputKind.Markdown ->
                                 ApiDocs.GenerateMarkdownPhased(


### PR DESCRIPTION
One thing that might be confusing is how we get the `input` folder value in the `listOfNamespacesNav` function. This PR does exactly that.